### PR TITLE
fix: curl 명령어 대기시간 2분으로 증가

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -2,21 +2,17 @@ name: Render Keep Alive Production
 
 on:
   schedule:
-    - cron: "*/14 * * * *"
+    - cron: "*/5 * * * *"
   workflow_dispatch:
 
 jobs:
   ping-server:
     runs-on: ubuntu-latest
-    timeout-minutes: 5 # 전체 Job의 타임아웃을 넉넉하게 5분으로 늘려줍니다.
+    timeout-minutes: 5
     
     steps:
       - name: Execute Health Check Request
         run: |
-          # -m 120: 타임아웃을 120초(2분)로 연장하여 콜드 스타트를 기다려줍니다.
-          # --retry 3: 실패 시 최대 3번까지 재시도합니다.
-          # --retry-delay 5: 재시도 사이에 5초의 대기 시간을 가집니다.
-          # --retry-connrefused: 연결 거부 시에도 재시도를 수행합니다.
           curl -f -s -S -m 120 \
           --retry 3 \
           --retry-delay 5 \


### PR DESCRIPTION
## #️⃣ 연관된 이슈

resolves #13 

### 📝 작업 내용

ping의 대기시간을 10초만 설정했기 때문에, render가 휴면일 때 콜드 스타트를 기다리지 못하고 실패로 처리했던 버그를 해결합니다.
ping 대기시간을 120초로 늘려 해결합니다.
콜드 스타트만 1차로 깨워도 현재 상태의 크론잡이 잘 돌아가지만, 14분 간격은 조금만 순위가 밀려도 15분을 넘겨 다시 잠들기 때문에 ping의 5분으로 간격을 줄였습니다.

### 스크린샷 (선택)
<img width="702" height="470" alt="스크린샷 2026-03-16 오후 11 29 54" src="https://github.com/user-attachments/assets/47a42f0a-646e-4363-aab5-0a93e41b43ae" />

## 💬 리뷰 요구사항(선택)


## 📚 참고할만한 자료(선택)
