### PR TITLE
Feature/enable-cors-frontend-deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,8 +36,8 @@ DATABASE_URL=postgres://user:password@host:port/dbname
 # ------------------------------------------------------------------------------
 # 4. Security & Authentication (인증 및 보안 설정 - 예비)
 # ------------------------------------------------------------------------------
-# CORS 허용 출처 (운영 환경에서는 프론트엔드 도메인으로 제한)
-CORS_ORIGIN=http://localhost:3000
+# CORS 허용 출처 (쉼표로 여러 출처 지정 가능)
+CORS_ORIGIN=http://localhost:3000,https://webfull-9-10-sabujak-fe.vercel.app
 
 # ------------------------------------------------------------------------------
 # 5. Docker Development Optimization (OS 호환성 최적화)

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",
     "@types/express-rate-limit": "^6.0.2",
     "@types/node": "^20.19.37",
@@ -40,6 +41,7 @@
     "typescript-eslint": "^8.57.0"
   },
   "dependencies": {
+    "cors": "^2.8.6",
     "dotenv": "^17.3.1",
     "express": "^5.2.1",
     "express-rate-limit": "^8.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  cors:
+    specifier: ^2.8.6
+    version: 2.8.6
   dotenv:
     specifier: ^17.3.1
     version: 17.3.1
@@ -22,6 +25,9 @@ devDependencies:
   '@eslint/js':
     specifier: ^10.0.1
     version: 10.0.1(eslint@10.0.3)
+  '@types/cors':
+    specifier: ^2.8.19
+    version: 2.8.19
   '@types/express':
     specifier: ^5.0.6
     version: 5.0.6
@@ -396,6 +402,12 @@ packages:
       '@types/node': 20.19.37
     dev: true
 
+  /@types/cors@2.8.19:
+    resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
+    dependencies:
+      '@types/node': 20.19.37
+    dev: true
+
   /@types/esrecurse@4.3.1:
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
     dev: true
@@ -757,6 +769,14 @@ packages:
   /cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
+
+  /cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+    dev: false
 
   /cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1431,6 +1451,11 @@ packages:
     dependencies:
       path-key: 4.0.0
     dev: true
+
+  /object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+    dev: false
 
   /object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,25 @@
+import "dotenv/config";
+import cors from "cors";
 import express from "express";
 import appRouter from "./app/app.route";
 
 const app = express();
+const PORT = process.env.API_PORT || 3000;
+const allowedOrigins = (process.env.CORS_ORIGIN || "")
+  .split(",")
+  .map((origin) => origin.trim())
+  .filter(Boolean);
 
 // Render 환견에서 리버스 프록시(로드밸런서)를 거쳐 들어오는 실제 클라이언트 IP를 정상적으로 식별하기 위해 단일 로드밸런서를 신뢰합니다.
 // 이 설정이 없으면 모든 요청이 로드밸런서의 동일한 IP로 인식되어 rate-limit이 모든 사용자에게 동시에 적용됩니다.
 app.set("trust proxy", 1);
 
+app.use(
+  cors({
+    origin: allowedOrigins,
+  }),
+);
 app.use("/", appRouter);
-
-const PORT = process.env.API_PORT || 3000;
 
 app.listen(PORT, () => {
   console.log(`Server running on ${PORT}`);


### PR DESCRIPTION
#️⃣ 연관된 이슈

> resovles #18

### 📝 작업 내용

- 프론트엔드 배포 주소 `https://webfull-9-10-sabujak-fe.vercel.app` 에서 백엔드 API 호출이 가능하도록 CORS 설정을 추가했습니다.
- Express 서버에 `cors` 패키지를 적용하고, `CORS_ORIGIN` 환경변수에 정의된 origin 목록을 허용하도록 구성했습니다.
- `CORS_ORIGIN`이 쉼표 구분 다중 origin 값을 받을 수 있도록 처리해 로컬 프론트와 배포 프론트를 함께 허용할 수 있게 했습니다.
- `.env.example`에 Vercel 배포 주소를 반영해 환경변수 예시를 최신화했습니다.
- `cors`, `@types/cors` 의존성을 추가했습니다.

### 스크린샷 (선택)

- 해당 없음

## 💬 리뷰 요구사항(선택)

.env에다 .env.example처럼 cors 주소를 추가해줘야합니다.

## 📚 참고할만한 자료(선택)

- 프론트 배포 주소: `https://webfull-9-10-sabujak-fe.vercel.app/`