### PR TITLE
fix: Render 배포 환경에서 Swagger 문서가 뜨지 않는 문제 수정

### DIFF
--- a/src/app/app.controller.ts
+++ b/src/app/app.controller.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import { Request, Response } from "express";
 import pool from "./db";
 import {
@@ -18,6 +17,7 @@ import {
   updateCapsuleResponseSchema,
   verifyPasswordResponseSchema,
 } from "../schemas/capsules.schema";
+import { openApiDocument } from "../openapi/registry";
 
 const getSlugParam = (slug: string | string[] | undefined) =>
   Array.isArray(slug) ? slug[0] : slug;
@@ -88,5 +88,5 @@ export const createMessage = (req: Request, res: Response) => {
 };
 
 export const getOpenApiDocument = (req: Request, res: Response) => {
-  res.sendFile(path.resolve(process.cwd(), "openapi.json"));
+  res.json(openApiDocument);
 };

--- a/src/app/app.route.ts
+++ b/src/app/app.route.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import rateLimit from "express-rate-limit";
 import swaggerUi from "swagger-ui-express";
+import { openApiDocument } from "../openapi/registry";
 import {
   createCapsule,
   createMessage,
@@ -51,11 +52,8 @@ router.get("/openapi.json", getOpenApiDocument);
 router.use(
   "/api-docs",
   swaggerUi.serve,
-  swaggerUi.setup(undefined, {
+  swaggerUi.setup(openApiDocument, {
     customSiteTitle: "Sabujak API Docs",
-    swaggerOptions: {
-      url: "/openapi.json",
-    },
   }),
 );
 router.post("/capsules/slug-reservations", createSlugReservation);

--- a/src/openapi/registry.ts
+++ b/src/openapi/registry.ts
@@ -269,3 +269,5 @@ export const generateOpenApiDocument = () => {
     ],
   });
 };
+
+export const openApiDocument = generateOpenApiDocument();


### PR DESCRIPTION
## #️⃣ 연관된 이슈

resolves #27 

### 📝 작업 내용

왜 이 작업을 했는가:
Render에 배포한 뒤 /api-docs에 접속하면 Swagger UI가 /openapi.json을 불러오지 못하고 404가 발생했습니다. 원인은 서버가 런타임에 /app/openapi.json 파일을 직접 찾도록 되어 있었는데, 배포 환경에서는 그 파일 경로를 항상 신뢰할 수 없었기 때문입니다.

어떤 작업을 어떻게 했는가:
- OpenAPI 문서를 파일 경로에서 읽는 대신, 런타임에 메모리에서 바로 사용할 수 있는 openApiDocument를 registry에서 export 하도록 변경했습니다.
- /openapi.json 응답도 sendFile이 아니라 res.json(openApiDocument)로 바꿨습니다.
- Swagger UI도 url로 외부 파일을 다시 요청하는 방식 대신, openApiDocument 객체를 직접 넘겨 렌더링하도록 변경했습니다.

왜 이렇게 했는가:
이 방식은 배포 환경의 파일 시스템 상태에 덜 의존합니다.
즉, openapi.json 파일이 런타임 경로에 실제로 존재하지 않아도,
서버 코드만 정상적으로 실행되면 /openapi.json과 /api-docs를 모두 안정적으로 제공할 수 있습니다.

기대 효과:
- Render에서 /openapi.json 404 방지
- Swagger UI가 배포 환경에서도 바로 로드됨
- Orval용 정적 openapi.json은 그대로 유지하면서, 서버 런타임은 더 안전해짐

검증:
- pnpm lint
- 변경 범위를 controller, route, registry 3개 파일로 제한

### 스크린샷 (선택)
<img width="492" height="584" alt="스크린샷 2026-03-19 오후 3 50 38" src="https://github.com/user-attachments/assets/9e1aedbd-15e3-4cb1-9722-79f3298e278b" />

## 💬 리뷰 요구사항(선택)

배포환경(build, start) 하고 openapi.json 찾아보니 잘 나오네요!

## 📚 참고할만한 자료(선택)
