### PR TITLE
fix: duplicate nickname 충돌을 409로 변환하도록 예외 처리 보강

### DIFF
--- a/src/modules/capsules/capsules.repository.test.ts
+++ b/src/modules/capsules/capsules.repository.test.ts
@@ -68,6 +68,12 @@ const buildDrizzleUniqueViolationError = (constraint: string) => ({
     constraint,
   },
 });
+const buildLayeredUniqueConstraintMismatchError = (constraint: string) => ({
+  code: "23505",
+  cause: {
+    constraint,
+  },
+});
 
 describe("CapsulesRepository", () => {
   const buildPasswordHash = (password: string) => {
@@ -247,6 +253,74 @@ describe("CapsulesRepository", () => {
           reservationToken: "valid-token",
         }),
       ).rejects.toBe(unexpectedError);
+    });
+
+    it("code와 constraint가 서로 다른 error 레벨에 있으면 원본 에러를 그대로 던진다", async () => {
+      getRedisStringValue.mockResolvedValue("valid-token");
+
+      const layeredError = buildLayeredUniqueConstraintMismatchError(
+        "capsules_slug_unq",
+      );
+      const returningMock = jest.fn().mockRejectedValue(layeredError);
+      const valuesMock = jest.fn().mockReturnValue({ returning: returningMock });
+      db.insert.mockReturnValue({ values: valuesMock });
+
+      await expect(
+        capsulesRepository.createCapsule({
+          slug: "duplicate-slug",
+          title: "중복 캡슐",
+          password: "1234",
+          openAt: "2026-12-25T12:00:00.000Z",
+          reservationToken: "valid-token",
+        }),
+      ).rejects.toBe(layeredError);
+    });
+
+    it("Redis 예약 정리 실패가 발생해도 캡슐 생성 성공 응답을 반환한다", async () => {
+      const consoleErrorSpy = jest
+        .spyOn(console, "error")
+        .mockImplementation(() => undefined);
+
+      getRedisStringValue.mockResolvedValue("valid-token");
+      deleteRedisKey.mockRejectedValue(new Error("redis delete failed"));
+
+      const returningMock = jest.fn().mockResolvedValue([
+        {
+          id: "01TESTCAPSULEID123456789012",
+          slug: "created-slug",
+          title: "생성된 캡슐",
+          openAt: new Date("2026-12-25T12:00:00.000Z"),
+          expiresAt: new Date("2027-01-01T12:00:00.000Z"),
+          createdAt: new Date("2026-03-23T00:00:00.000Z"),
+          updatedAt: new Date("2026-03-23T00:00:00.000Z"),
+        },
+      ]);
+      const valuesMock = jest.fn().mockReturnValue({ returning: returningMock });
+      db.insert.mockReturnValue({ values: valuesMock });
+
+      const result = await capsulesRepository.createCapsule({
+        slug: "created-slug",
+        title: "생성된 캡슐",
+        password: "1234",
+        openAt: "2026-12-25T12:00:00.000Z",
+        reservationToken: "valid-token",
+      });
+
+      expect(result).toEqual({
+        id: "01TESTCAPSULEID123456789012",
+        slug: "created-slug",
+        title: "생성된 캡슐",
+        openAt: "2026-12-25T12:00:00.000Z",
+        expiresAt: "2027-01-01T12:00:00.000Z",
+        createdAt: "2026-03-23T00:00:00.000Z",
+        updatedAt: "2026-03-23T00:00:00.000Z",
+      });
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "[capsules] Failed to clean up slug reservation after capsule creation.",
+        expect.any(Error),
+      );
+
+      consoleErrorSpy.mockRestore();
     });
   });
 
@@ -539,6 +613,39 @@ describe("CapsulesRepository", () => {
           content: "메시지",
         }),
       ).rejects.toBe(unexpectedError);
+    });
+
+    it("code와 constraint가 서로 다른 error 레벨에 있으면 원본 에러를 그대로 던진다", async () => {
+      db.query.capsules.findFirst.mockResolvedValue({
+        id: "01TESTCAPSULEID123456789012",
+        expiresAt: FUTURE_DATE,
+      });
+      const countWhereMock = jest.fn().mockResolvedValue([{ messageCount: 0 }]);
+      const countFromMock = jest.fn().mockReturnValue({ where: countWhereMock });
+      db.select.mockReturnValue({ from: countFromMock });
+
+      const layeredError = buildLayeredUniqueConstraintMismatchError(
+        "messages_capsule_id_nickname_unq",
+      );
+      const messageReturningMock = jest.fn().mockRejectedValue(layeredError);
+      const messageValuesMock = jest
+        .fn()
+        .mockReturnValue({ returning: messageReturningMock });
+      const txInsertMock = jest.fn().mockReturnValue({ values: messageValuesMock });
+      db.transaction.mockImplementation(async (callback) =>
+        callback({
+          insert: txInsertMock,
+          update: jest.fn(),
+        }),
+      );
+
+      await expect(
+        capsulesRepository.createMessage({
+          slug: "opened-capsule",
+          nickname: "중복 닉네임",
+          content: "메시지",
+        }),
+      ).rejects.toBe(layeredError);
     });
   });
 

--- a/src/modules/capsules/capsules.repository.ts
+++ b/src/modules/capsules/capsules.repository.ts
@@ -109,36 +109,26 @@ const calculateExpiresAt = (openAt: Date) => {
   );
 };
 
-const getNestedErrorValue = (
-  error: unknown,
-  key: "code" | "constraint",
-): string | undefined => {
-  if (typeof error !== "object" || error === null) {
-    return undefined;
-  }
-
-  const record = error as Record<string, unknown>;
-  const value = record[key];
-
-  if (typeof value === "string") {
-    return value;
-  }
-
-  if ("cause" in record) {
-    return getNestedErrorValue(record.cause, key);
-  }
-
-  return undefined;
-};
-
 const isUniqueConstraintViolation = (
   error: unknown,
   constraint: string,
 ): boolean => {
-  return (
-    getNestedErrorValue(error, "code") === POSTGRES_UNIQUE_VIOLATION_CODE &&
-    getNestedErrorValue(error, "constraint") === constraint
-  );
+  let currentError: unknown = error;
+
+  while (typeof currentError === "object" && currentError !== null) {
+    const record = currentError as Record<string, unknown>;
+
+    if (
+      record.code === POSTGRES_UNIQUE_VIOLATION_CODE &&
+      record.constraint === constraint
+    ) {
+      return true;
+    }
+
+    currentError = record.cause;
+  }
+
+  return false;
 };
 
 export class CapsulesRepository {
@@ -210,10 +200,7 @@ export class CapsulesRepository {
         })
         .returning();
 
-      // 사용이 끝난 예약은 즉시 제거해 동일 토큰 재사용을 막습니다.
-      await deleteRedisKey(reservationKey);
-
-      return {
+      const response = {
         id: createdCapsule.id,
         slug: createdCapsule.slug,
         title: createdCapsule.title,
@@ -222,6 +209,18 @@ export class CapsulesRepository {
         createdAt: createdCapsule.createdAt.toISOString(),
         updatedAt: createdCapsule.updatedAt.toISOString(),
       };
+
+      try {
+        // 사용이 끝난 예약은 즉시 제거해 동일 토큰 재사용을 막습니다.
+        await deleteRedisKey(reservationKey);
+      } catch (error) {
+        console.error(
+          "[capsules] Failed to clean up slug reservation after capsule creation.",
+          error,
+        );
+      }
+
+      return response;
     } catch (error) {
       if (isUniqueConstraintViolation(error, CAPSULE_SLUG_UNIQUE_CONSTRAINT)) {
         throw new SlugAlreadyInUseException();


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #61

### 📝 작업 내용

- Drizzle이 감싼 PostgreSQL unique violation을 `cause` 체인에서 노드 단위로 검사하도록 예외 판별 로직을 정리했습니다.
- `messages_capsule_id_nickname_unq` 제약 위반일 때만 `DuplicateNicknameException`으로 변환되도록 보강해 duplicate nickname 충돌이 `409`로 내려가게 수정했습니다.
- 같은 유형의 누락이 있던 `capsules_slug_unq`도 함께 보강해 slug unique 충돌이 `500`으로 새지 않도록 정리했습니다.
- `code`와 `constraint`가 서로 다른 중첩 레벨에 있을 때 잘못 매칭되지 않도록 오탐 방지 테스트를 추가했습니다.
- 캡슐 생성 후 Redis 예약 정리 실패가 발생해도 이미 성공한 DB 저장 결과는 그대로 반환하고, 후처리 실패만 로그로 남기도록 안정성을 보강했습니다.
- repository 테스트를 갱신해 대상 제약만 도메인 예외로 변환되고 다른 unique 제약이나 잘못된 중첩 구조는 원본 에러를 유지하는 케이스까지 검증했습니다.
- 검증:
  - `pnpm test -- --runTestsByPath src/modules/capsules/capsules.repository.test.ts`
  - `pnpm test`
  - `pnpm run typecheck`
  - `pnpm exec eslint src/modules/capsules/capsules.repository.ts src/modules/capsules/capsules.repository.test.ts`

### 스크린샷 (선택)

- 없음

## 💬 리뷰 요구사항(선택)

- 없음

## 📚 참고할만한 자료(선택)

- QA 보고서: `docs/reports/2026-03-25-main-qa-incident-report.md`
- 대응 계획: `docs/reports/2026-03-25-main-qa-countermeasure-plan.md`
