### PR TITLE
fix: 캡슐 unique constraint 예외 처리 안정성 보강

### DIFF
--- a/src/modules/capsules/capsules.repository.test.ts
+++ b/src/modules/capsules/capsules.repository.test.ts
@@ -71,6 +71,12 @@ const buildLayeredUniqueConstraintMismatchError = (constraint: string) => ({
     constraint,
   },
 });
+const buildErrorWrappedUniqueViolationError = (constraint: string) => ({
+  error: {
+    code: "23505",
+    constraint,
+  },
+});
 
 describe("CapsulesRepository", () => {
   const buildPasswordHash = (password: string) => {
@@ -259,6 +265,30 @@ describe("CapsulesRepository", () => {
       ).rejects.toBe(unexpectedError);
     });
 
+    it("error 속성에 감싼 slug unique constraint 충돌도 SlugAlreadyInUseException으로 변환한다", async () => {
+      getRedisStringValue.mockResolvedValue("valid-token");
+
+      const returningMock = jest
+        .fn()
+        .mockRejectedValue(
+          buildErrorWrappedUniqueViolationError("capsules_slug_unq"),
+        );
+      const valuesMock = jest
+        .fn()
+        .mockReturnValue({ returning: returningMock });
+      db.insert.mockReturnValue({ values: valuesMock });
+
+      await expect(
+        capsulesRepository.createCapsule({
+          slug: "duplicate-slug",
+          title: "중복 캡슐",
+          password: "1234",
+          openAt: "2026-12-25T12:00:00.000Z",
+          reservationToken: "valid-token",
+        }),
+      ).rejects.toBeInstanceOf(SlugAlreadyInUseException);
+    });
+
     it("code와 constraint가 서로 다른 error 레벨에 있으면 원본 에러를 그대로 던진다", async () => {
       getRedisStringValue.mockResolvedValue("valid-token");
 
@@ -279,6 +309,29 @@ describe("CapsulesRepository", () => {
           reservationToken: "valid-token",
         }),
       ).rejects.toBe(layeredError);
+    });
+
+    it("cause가 순환 참조여도 무한 루프 없이 원본 에러를 그대로 던진다", async () => {
+      getRedisStringValue.mockResolvedValue("valid-token");
+
+      const circularError: { cause?: unknown } = {};
+      circularError.cause = circularError;
+
+      const returningMock = jest.fn().mockRejectedValue(circularError);
+      const valuesMock = jest
+        .fn()
+        .mockReturnValue({ returning: returningMock });
+      db.insert.mockReturnValue({ values: valuesMock });
+
+      await expect(
+        capsulesRepository.createCapsule({
+          slug: "duplicate-slug",
+          title: "중복 캡슐",
+          password: "1234",
+          openAt: "2026-12-25T12:00:00.000Z",
+          reservationToken: "valid-token",
+        }),
+      ).rejects.toBe(circularError);
     });
 
     it("Redis 예약 정리 실패가 발생해도 캡슐 생성 성공 응답을 반환한다", async () => {
@@ -650,6 +703,47 @@ describe("CapsulesRepository", () => {
       ).rejects.toBe(unexpectedError);
     });
 
+    it("error 속성에 감싼 nickname unique constraint 충돌도 DuplicateNicknameException으로 변환한다", async () => {
+      db.query.capsules.findFirst.mockResolvedValue({
+        id: "01TESTCAPSULEID123456789012",
+        openAt: FUTURE_DATE,
+        expiresAt: FUTURE_DATE,
+      });
+      const countWhereMock = jest.fn().mockResolvedValue([{ messageCount: 0 }]);
+      const countFromMock = jest
+        .fn()
+        .mockReturnValue({ where: countWhereMock });
+      db.select.mockReturnValue({ from: countFromMock });
+
+      const messageReturningMock = jest
+        .fn()
+        .mockRejectedValue(
+          buildErrorWrappedUniqueViolationError(
+            "messages_capsule_id_nickname_unq",
+          ),
+        );
+      const messageValuesMock = jest
+        .fn()
+        .mockReturnValue({ returning: messageReturningMock });
+      const txInsertMock = jest
+        .fn()
+        .mockReturnValue({ values: messageValuesMock });
+      db.transaction.mockImplementation(async (callback) =>
+        callback({
+          insert: txInsertMock,
+          update: jest.fn(),
+        }),
+      );
+
+      await expect(
+        capsulesRepository.createMessage({
+          slug: "opened-capsule",
+          nickname: "중복 닉네임",
+          content: "메시지",
+        }),
+      ).rejects.toBeInstanceOf(DuplicateNicknameException);
+    });
+
     it("code와 constraint가 서로 다른 error 레벨에 있으면 원본 에러를 그대로 던진다", async () => {
       db.query.capsules.findFirst.mockResolvedValue({
         id: "01TESTCAPSULEID123456789012",
@@ -686,6 +780,44 @@ describe("CapsulesRepository", () => {
           content: "메시지",
         }),
       ).rejects.toBe(layeredError);
+    });
+
+    it("cause가 순환 참조여도 무한 루프 없이 원본 에러를 그대로 던진다", async () => {
+      db.query.capsules.findFirst.mockResolvedValue({
+        id: "01TESTCAPSULEID123456789012",
+        openAt: FUTURE_DATE,
+        expiresAt: FUTURE_DATE,
+      });
+      const countWhereMock = jest.fn().mockResolvedValue([{ messageCount: 0 }]);
+      const countFromMock = jest
+        .fn()
+        .mockReturnValue({ where: countWhereMock });
+      db.select.mockReturnValue({ from: countFromMock });
+
+      const circularError: { cause?: unknown } = {};
+      circularError.cause = circularError;
+
+      const messageReturningMock = jest.fn().mockRejectedValue(circularError);
+      const messageValuesMock = jest
+        .fn()
+        .mockReturnValue({ returning: messageReturningMock });
+      const txInsertMock = jest
+        .fn()
+        .mockReturnValue({ values: messageValuesMock });
+      db.transaction.mockImplementation(async (callback) =>
+        callback({
+          insert: txInsertMock,
+          update: jest.fn(),
+        }),
+      );
+
+      await expect(
+        capsulesRepository.createMessage({
+          slug: "opened-capsule",
+          nickname: "중복 닉네임",
+          content: "메시지",
+        }),
+      ).rejects.toBe(circularError);
     });
   });
 

--- a/src/modules/capsules/capsules.repository.ts
+++ b/src/modules/capsules/capsules.repository.ts
@@ -112,9 +112,24 @@ const isUniqueConstraintViolation = (
   error: unknown,
   constraint: string,
 ): boolean => {
-  let currentError: unknown = error;
+  const queue: unknown[] = [error];
+  const visited = new Set<object>();
+  let inspectedCount = 0;
 
-  while (typeof currentError === "object" && currentError !== null) {
+  while (queue.length > 0 && inspectedCount < 10) {
+    const currentError = queue.shift();
+
+    if (typeof currentError !== "object" || currentError === null) {
+      continue;
+    }
+
+    if (visited.has(currentError)) {
+      continue;
+    }
+
+    visited.add(currentError);
+    inspectedCount += 1;
+
     const record = currentError as Record<string, unknown>;
 
     if (
@@ -124,7 +139,7 @@ const isUniqueConstraintViolation = (
       return true;
     }
 
-    currentError = record.cause;
+    queue.push(record.cause, record.error);
   }
 
   return false;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #61

### 📝 작업 내용

> 오래되어 충돌이 발생한 #62 PR에서 아직 유효한 안정성 보강만 최신 `main` 기준으로 다시 정리했습니다.

- slug 중복 처리 시 Postgres 에러 코드(`23505`)만 보지 않고 실제 constraint 이름(`capsules_slug_unq`)까지 확인하도록 보강했습니다.
- 메시지 닉네임 중복 처리 시에도 대상 constraint(`messages_capsule_id_nickname_unq`)를 명시적으로 확인하도록 보강했습니다.
- 캡슐 생성 후 Redis slug reservation 삭제가 실패하더라도 생성 성공 응답은 유지하고, 에러 로그만 남기도록 변경했습니다.
- 위 시나리오들을 검증하는 회귀 테스트를 추가했습니다.

### 스크린샷 (선택)

- 없음

## 💬 리뷰 요구사항(선택)

> #62에서 이미 `main`에 반영된 닉네임 409 처리와 겹치지 않도록, 남아 있던 안정성 보강만 가져온 상태입니다.
>
> constraint 이름 기반 판별 범위가 현재 의도에 맞는지만 중점적으로 봐주시면 됩니다.

## 📚 참고할만한 자료(선택)

- 대체한 기존 PR: #62
- 테스트: `pnpm test -- src/modules/capsules/capsules.repository.test.ts`