### PR TITLE
chore: 프론트 Orval 동기화 디스패치 워크플로우 추가

### DIFF
--- a/.github/workflows/dispatch-frontend-orval-sync.yml
+++ b/.github/workflows/dispatch-frontend-orval-sync.yml
@@ -1,0 +1,27 @@
+name: Dispatch Frontend Orval Sync
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - openapi.json
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    name: Notify frontend repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Dispatch repository event
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.FRONTEND_REPO_DISPATCH_TOKEN }}
+          repository: prgrms-fullcycle-devcourse/webfull_9_10_Sabujak_FE
+          event-type: backend-openapi-updated
+          client-payload: >-
+            {"backend_sha":"${{ github.sha }}","backend_repository":"${{ github.repository }}"}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 없음

### 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- 백엔드 `main`에 `openapi.json` 변경이 반영되면 프론트엔드 저장소로 `repository_dispatch` 이벤트를 전송하는 GitHub Actions 워크플로우를 추가했습니다.
- 프론트엔드 저장소의 Orval 생성 자동화를 안정적으로 트리거할 수 있도록 이벤트 payload에 백엔드 저장소명과 커밋 SHA를 포함했습니다.
- 기존 백엔드 코드 변경과 분리해서 워크플로우만 독립적으로 적용할 수 있게 구성했습니다.

### 스크린샷 (선택)

- 없음

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- 프론트엔드 저장소명을 `prgrms-fullcycle-devcourse/webfull_9_10_Sabujak_FE`로 고정했는데, 가변적으로 설계하고싶다는 생각이 들었어요. (레포명이 바뀌어도 따라갈 수 있으면 좋겠다?)

## 📚 참고할만한 자료(선택)

- GitHub Secrets 등록 방법
  1. 백엔드 저장소의 `Settings > Secrets and variables > Actions`로 이동합니다.
  2. `New repository secret`을 눌러 `FRONTEND_REPO_DISPATCH_TOKEN` 이름으로 등록합니다.
  3. 값은 프론트엔드 저장소에 접근 가능한 Personal Access Token 또는 GitHub App 토큰을 사용합니다.
  4. 필요한 권한은 최소 `repo`, `workflow` 수준이며 프론트엔드 저장소에 브랜치 푸시와 PR 생성이 가능해야 합니다.
- 이 워크플로우는 `main` 브랜치에서 `openapi.json`이 바뀐 경우에만 동작합니다.
