### PR TITLE
fix: 운영 DB fallback 경로 차단

### DIFF
--- a/src/db/pool.test.ts
+++ b/src/db/pool.test.ts
@@ -1,5 +1,13 @@
 import { EventEmitter } from "node:events";
-import { bindPoolErrorHandler, createPoolConfig, poolErrorMessage } from "./pool";
+import {
+  bindPoolErrorHandler,
+  createPoolConfig,
+  createPoolDiagnostics,
+  formatPoolInitializationLog,
+  logPoolInitialization,
+  poolErrorMessage,
+  productionDatabaseUrlRequiredMessage,
+} from "./pool";
 
 class PoolStub extends EventEmitter {
   override on(event: "error", listener: (error: Error) => void) {
@@ -46,6 +54,14 @@ describe("createPoolConfig", () => {
     });
   });
 
+  it("fails fast in production when DATABASE_URL is missing", () => {
+    expect(() =>
+      createPoolConfig({
+        NODE_ENV: "production",
+      }),
+    ).toThrow(productionDatabaseUrlRequiredMessage);
+  });
+
   it("treats a blank DATABASE_URL as missing", () => {
     const env = {
       NODE_ENV: "development",
@@ -67,6 +83,66 @@ describe("createPoolConfig", () => {
       idleTimeoutMillis: 30_000,
       connectionTimeoutMillis: 10_000,
     });
+  });
+
+  it("fails fast in production when DATABASE_URL is blank", () => {
+    expect(() =>
+      createPoolConfig({
+        NODE_ENV: "production",
+        DATABASE_URL: "   ",
+      }),
+    ).toThrow(productionDatabaseUrlRequiredMessage);
+  });
+});
+
+describe("createPoolDiagnostics", () => {
+  it("reports the DATABASE_URL host without exposing credentials", () => {
+    expect(
+      createPoolDiagnostics({
+        NODE_ENV: "production",
+        DATABASE_URL:
+          "postgres://user:password@ep-cool-glade.ap-southeast-1.aws.neon.tech:5432/app?sslmode=require",
+      }),
+    ).toEqual({
+      environment: "production",
+      source: "database_url",
+      host: "ep-cool-glade.ap-southeast-1.aws.neon.tech",
+      ssl: "enabled",
+      maxConnections: 5,
+    });
+  });
+});
+
+describe("logPoolInitialization", () => {
+  it("logs whether the pool uses the local fallback", () => {
+    const logger = jest.fn();
+
+    logPoolInitialization(
+      createPoolDiagnostics({
+        NODE_ENV: "development",
+        POSTGRES_USER: "local-user",
+        POSTGRES_PASSWORD: "local-password",
+        POSTGRES_DB: "local-db",
+      }),
+      logger,
+    );
+
+    expect(logger).toHaveBeenCalledWith(
+      "[db] Initializing PostgreSQL pool. env=development source=local_fallback host=db ssl=disabled max=10",
+    );
+  });
+
+  it("formats diagnostics for DATABASE_URL based connections", () => {
+    expect(
+      formatPoolInitializationLog(
+        createPoolDiagnostics({
+          NODE_ENV: "production",
+          DATABASE_URL: "postgres://user:password@host:5432/db",
+        }),
+      ),
+    ).toBe(
+      "[db] Initializing PostgreSQL pool. env=production source=database_url host=host ssl=enabled max=5",
+    );
   });
 });
 

--- a/src/db/pool.ts
+++ b/src/db/pool.ts
@@ -2,13 +2,32 @@ import { Pool, type PoolConfig } from "pg";
 
 const poolErrorMessage =
   "[db] Unexpected PostgreSQL pool error. The pool will recover on the next connection checkout.";
+const productionDatabaseUrlRequiredMessage =
+  '[db] DATABASE_URL must be set in production. Refusing to fall back to local host "db".';
+const poolInitializationLogPrefix = "[db] Initializing PostgreSQL pool.";
 
 type PoolLike = {
   on(event: "error", listener: (error: Error) => void): unknown;
 };
 type PoolErrorLogger = (message: string, error: Error) => void;
+type PoolInitializationLogger = (message: string) => void;
+
+type PoolConnectionSource = "database_url" | "local_fallback";
+
+type PoolDiagnostics = {
+  environment: string;
+  source: PoolConnectionSource;
+  host: string;
+  ssl: "enabled" | "disabled";
+  maxConnections: number;
+};
 
 type PoolEnv = NodeJS.ProcessEnv;
+type CreatePoolOptions = {
+  env?: PoolEnv;
+  initializationLogger?: PoolInitializationLogger;
+  errorLogger?: PoolErrorLogger;
+};
 
 const normalizeConnectionString = (connectionString?: string) => {
   const trimmedConnectionString = connectionString?.trim();
@@ -16,11 +35,28 @@ const normalizeConnectionString = (connectionString?: string) => {
   return trimmedConnectionString ? trimmedConnectionString : undefined;
 };
 
-export const createPoolConfig = (env: PoolEnv = process.env): PoolConfig => {
+const resolvePoolHost = (connectionString?: string) => {
+  if (!connectionString) {
+    return "db";
+  }
+
+  try {
+    return new URL(connectionString).hostname || "unparseable";
+  } catch {
+    return "unparseable";
+  }
+};
+
+const resolvePoolConfiguration = (env: PoolEnv = process.env) => {
   const isProduction = env.NODE_ENV === "production";
   const connectionString = normalizeConnectionString(env.DATABASE_URL);
+  const maxConnections = isProduction ? 5 : 10;
 
-  return {
+  if (isProduction && !connectionString) {
+    throw new Error(productionDatabaseUrlRequiredMessage);
+  }
+
+  const config: PoolConfig = {
     connectionString,
     ...(!connectionString && {
       host: "db",
@@ -30,10 +66,41 @@ export const createPoolConfig = (env: PoolEnv = process.env): PoolConfig => {
       database: env.POSTGRES_DB,
     }),
     ssl: isProduction ? { rejectUnauthorized: false } : false,
-    max: isProduction ? 5 : 10,
+    max: maxConnections,
     idleTimeoutMillis: 30_000,
     connectionTimeoutMillis: 10_000,
   };
+
+  const diagnostics: PoolDiagnostics = {
+    environment: env.NODE_ENV ?? "undefined",
+    source: connectionString ? "database_url" : "local_fallback",
+    host: resolvePoolHost(connectionString),
+    ssl: isProduction ? "enabled" : "disabled",
+    maxConnections,
+  };
+
+  return { config, diagnostics };
+};
+
+export const createPoolConfig = (env: PoolEnv = process.env): PoolConfig => {
+  return resolvePoolConfiguration(env).config;
+};
+
+export const createPoolDiagnostics = (
+  env: PoolEnv = process.env,
+): PoolDiagnostics => {
+  return resolvePoolConfiguration(env).diagnostics;
+};
+
+export const formatPoolInitializationLog = (diagnostics: PoolDiagnostics) => {
+  return `${poolInitializationLogPrefix} env=${diagnostics.environment} source=${diagnostics.source} host=${diagnostics.host} ssl=${diagnostics.ssl} max=${diagnostics.maxConnections}`;
+};
+
+export const logPoolInitialization = (
+  diagnostics: PoolDiagnostics,
+  logger: PoolInitializationLogger = console.info,
+) => {
+  logger(formatPoolInitializationLog(diagnostics));
 };
 
 export const bindPoolErrorHandler = (
@@ -45,12 +112,20 @@ export const bindPoolErrorHandler = (
   });
 };
 
-export const createPool = () => {
-  const pool = new Pool(createPoolConfig());
+export const createPool = (options: CreatePoolOptions = {}) => {
+  const env = options.env ?? process.env;
+  const { config, diagnostics } = resolvePoolConfiguration(env);
+  const pool = new Pool(config);
 
-  bindPoolErrorHandler(pool);
+  logPoolInitialization(diagnostics, options.initializationLogger);
+
+  bindPoolErrorHandler(pool, options.errorLogger);
 
   return pool;
 };
 
-export { poolErrorMessage };
+export {
+  poolErrorMessage,
+  poolInitializationLogPrefix,
+  productionDatabaseUrlRequiredMessage,
+};

--- a/src/db/retry.test.ts
+++ b/src/db/retry.test.ts
@@ -25,6 +25,13 @@ describe("isRetryableDbConnectionError", () => {
       false,
     );
   });
+
+  it("does not treat ENOTFOUND as retryable", () => {
+    const error = new Error("getaddrinfo ENOTFOUND db");
+    Object.assign(error, { code: "ENOTFOUND" });
+
+    expect(isRetryableDbConnectionError(error)).toBe(false);
+  });
 });
 
 describe("withDbConnectionRetry", () => {

--- a/src/db/retry.ts
+++ b/src/db/retry.ts
@@ -10,6 +10,8 @@ const RETRYABLE_DB_ERROR_CODES = new Set([
   "ECONNRESET",
   "ECONNREFUSED",
   "ETIMEDOUT",
+  // ENOTFOUND is intentionally excluded so configuration mistakes such as
+  // falling back to a local-only host fail fast instead of being retried.
 ]);
 
 const RETRYABLE_DB_ERROR_MESSAGE = [


### PR DESCRIPTION
## 요약
- 운영 환경에서 `DATABASE_URL`이 없거나 공백이면 즉시 실패하도록 해 로컬 `db` fallback 경로를 차단했습니다.
- DB pool 초기화 시 연결 소스(`database_url` 또는 `local_fallback`)와 host를 진단 로그로 남기도록 했습니다.
- `ENOTFOUND`를 retryable로 취급하지 않는 정책과 테스트를 보강했습니다.

## 배경
운영에서 `57P01 terminating connection due to administrator command` 이후 `getaddrinfo ENOTFOUND db`가 이어졌습니다.
이는 재연결 또는 초기화 경로에서 운영 환경이 로컬 Docker 전용 fallback host인 `db`를 참조했을 가능성을 시사합니다.

## 변경 내용
- `src/db/pool.ts`
  - 운영에서 `DATABASE_URL`이 비어 있으면 fail-fast 예외를 던지도록 수정
  - 연결 대상이 `DATABASE_URL` 기반인지 로컬 fallback 기반인지 구분되는 초기화 로그 추가
  - `DATABASE_URL`이 있을 때는 전체 URL 대신 hostname만 로그에 남기도록 처리
- `src/db/retry.ts`
  - `ENOTFOUND`는 설정 오류 또는 잘못된 host 가능성이 높아 retryable 목록에 추가하지 않음
- 테스트 보강
  - 운영 fail-fast 케이스 추가
  - pool 진단 로그 포맷 검증 추가
  - `ENOTFOUND` 비재시도 정책 검증 추가

## 검증
- `pnpm test`
- `pnpm typecheck`

## 이슈
- Closes #83
