### PR TITLE
hotfix: slug 예약 재확인 시 기존 예약 재사용 및 TTL 갱신

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@upstash/redis": "^1.37.0",
     "cors": "^2.8.6",
     "dotenv": "^17.3.1",
-    "drizzle-orm": "^0.45.1",
+    "drizzle-orm": "^0.45.2",
     "express": "^5.2.1",
     "express-rate-limit": "^8.3.1",
     "pg": "^8.20.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,8 +32,8 @@ importers:
         specifier: ^17.3.1
         version: 17.3.1
       drizzle-orm:
-        specifier: ^0.45.1
-        version: 0.45.1(@opentelemetry/api@1.9.1)(@types/pg@8.18.0)(@upstash/redis@1.37.0)(pg@8.20.0)
+        specifier: ^0.45.2
+        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.18.0)(@upstash/redis@1.37.0)(pg@8.20.0)
       express:
         specifier: ^5.2.1
         version: 5.2.1
@@ -1771,8 +1771,8 @@ packages:
     resolution: {integrity: sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==}
     hasBin: true
 
-  drizzle-orm@0.45.1:
-    resolution: {integrity: sha512-Te0FOdKIistGNPMq2jscdqngBRfBpC8uMFVwqjf6gtTVJHIQ/dosgV/CLBU2N4ZJBsXL5savCba9b0YJskKdcA==}
+  drizzle-orm@0.45.2:
+    resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
     peerDependencies:
       '@aws-sdk/client-rds-data': '>=3'
       '@cloudflare/workers-types': '>=4'
@@ -4859,7 +4859,7 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.21.0
 
-  drizzle-orm@0.45.1(@opentelemetry/api@1.9.1)(@types/pg@8.18.0)(@upstash/redis@1.37.0)(pg@8.20.0):
+  drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.18.0)(@upstash/redis@1.37.0)(pg@8.20.0):
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/pg': 8.18.0

--- a/src/modules/capsules/capsules.repository.test.ts
+++ b/src/modules/capsules/capsules.repository.test.ts
@@ -33,6 +33,7 @@ jest.mock("../../redis", () => ({
   getRedisSetMembers: jest.fn(),
   getRedisStringValue: jest.fn(),
   setRedisStringIfAbsent: jest.fn(),
+  setRedisStringValue: jest.fn(),
   deleteRedisKey: jest.fn(),
 }));
 
@@ -56,12 +57,14 @@ const {
   getRedisSetMembers,
   getRedisStringValue,
   setRedisStringIfAbsent,
+  setRedisStringValue,
   deleteRedisKey,
 } = jest.requireMock("../../redis") as {
   addRedisSetMembers: jest.Mock;
   getRedisSetMembers: jest.Mock;
   getRedisStringValue: jest.Mock;
   setRedisStringIfAbsent: jest.Mock;
+  setRedisStringValue: jest.Mock;
   deleteRedisKey: jest.Mock;
 };
 
@@ -126,6 +129,41 @@ describe("CapsulesRepository", () => {
       await expect(
         capsulesRepository.createSlugReservation({ slug: "reserved-slug" }),
       ).rejects.toBeInstanceOf(SlugAlreadyInUseException);
+    });
+
+    it("같은 세션이 같은 slug를 다시 확인하면 기존 예약을 재사용하고 TTL을 갱신한다", async () => {
+      db.query.capsules.findFirst.mockResolvedValue(null);
+      getRedisStringValue.mockResolvedValueOnce(
+        buildSlugReservationRecord("reserved-token", "session-a"),
+      );
+      setRedisStringValue.mockResolvedValue(undefined);
+      addRedisSetMembers.mockResolvedValue(undefined);
+
+      const result = await capsulesRepository.createSlugReservation({
+        slug: "reserved-slug",
+        reservationSessionToken: "session-a",
+      });
+
+      expect(result).toEqual({
+        slug: "reserved-slug",
+        reservationToken: "reserved-token",
+        reservationSessionToken: "session-a",
+        reservedUntil: expect.any(String),
+      });
+      expect(setRedisStringValue).toHaveBeenCalledWith(
+        "capsule:slug-reservation:reserved-slug",
+        JSON.stringify({
+          reservationToken: "reserved-token",
+          reservationSessionToken: "session-a",
+        }),
+        300,
+      );
+      expect(addRedisSetMembers).toHaveBeenCalledWith(
+        "capsule:slug-reservation-session:session-a",
+        ["reserved-slug"],
+        300,
+      );
+      expect(setRedisStringIfAbsent).not.toHaveBeenCalled();
     });
 
     it("사용 가능한 slug면 reservationSessionToken과 reservationToken을 함께 반환한다", async () => {

--- a/src/modules/capsules/capsules.repository.ts
+++ b/src/modules/capsules/capsules.repository.ts
@@ -8,6 +8,7 @@ import {
   getRedisSetMembers,
   getRedisStringValue,
   setRedisStringIfAbsent,
+  setRedisStringValue,
 } from "../../redis";
 import {
   CapsuleExpiredException,
@@ -249,10 +250,47 @@ export class CapsulesRepository {
 
     const reservationKey = getSlugReservationKey(input.slug);
     // 아직 생성되지 않은 slug라도, 활성 예약이 있으면 같은 slug를 다시 선점할 수 없습니다.
-    const existingReservation = await getRedisStringValue(reservationKey);
+    const existingReservation = parseSlugReservationRecord(
+      await getRedisStringValue(reservationKey),
+    );
 
     if (existingReservation) {
-      throw new SlugAlreadyInUseException();
+      const isSameSessionReservation =
+        Boolean(input.reservationSessionToken) &&
+        existingReservation.reservationSessionToken ===
+          input.reservationSessionToken;
+
+      if (!isSameSessionReservation) {
+        throw new SlugAlreadyInUseException();
+      }
+
+      const reservationSessionKey = getSlugReservationSessionKey(
+        existingReservation.reservationSessionToken,
+      );
+
+      // 같은 사용자가 같은 slug를 다시 확인하면 기존 예약을 재사용해
+      // 생성 직전 stale token mismatch가 나지 않도록 TTL만 연장합니다.
+      await Promise.all([
+        setRedisStringValue(
+          reservationKey,
+          JSON.stringify(existingReservation),
+          SLUG_RESERVATION_TTL_SECONDS,
+        ),
+        addRedisSetMembers(
+          reservationSessionKey,
+          [input.slug],
+          SLUG_RESERVATION_TTL_SECONDS,
+        ),
+      ]);
+
+      return {
+        slug: input.slug,
+        reservationToken: existingReservation.reservationToken,
+        reservationSessionToken: existingReservation.reservationSessionToken,
+        reservedUntil: new Date(
+          Date.now() + SLUG_RESERVATION_TTL_SECONDS * 1000,
+        ).toISOString(),
+      };
     }
 
     const reservationToken = randomUUID().replaceAll("-", "");


### PR DESCRIPTION
## 요약
- 같은 `reservationSessionToken`으로 같은 `slug`를 다시 중복 확인하면 기존 예약을 재사용하도록 수정했습니다.
- 재사용 시 예약 TTL을 갱신하도록 정리했습니다.
- 같은 세션/같은 slug 재확인 흐름을 회귀 테스트로 고정했습니다.

## 문제 재현
- 동일 세션에서 slug 중복 확인을 반복한 뒤 생성 요청을 보내면, 화면에서는 사용 가능으로 보이지만 `SLUG_RESERVATION_MISMATCH`가 발생할 수 있었습니다.

## 원인
- 예약 생성 로직이 세션 재확인 흐름을 idempotent하게 처리하지 못하고, 기존 Redis 예약을 재활용하지 않았습니다.

## 검증
- `npm test -- --runTestsByPath src/modules/capsules/capsules.repository.test.ts`
- `npm test -- --runTestsByPath src/modules/capsules/capsules.service.test.ts`
- 로컬 API 재현: `slug A 예약 -> slug B 예약 -> slug A 재예약 -> 생성` 흐름에서 `slug A` 재예약이 `201`, 첫 예약과 동일한 `reservationToken` 유지, 생성 `201`

## 관련 이슈
- Closes #92
