### PR TITLE
hotfix: Upstash Redis 응답 타입 호환으로 slug 예약 검증 복구

### DIFF
--- a/src/redis/index.test.ts
+++ b/src/redis/index.test.ts
@@ -1,0 +1,97 @@
+const originalEnv = { ...process.env };
+
+type UpstashClientMock = {
+  get: jest.Mock;
+  ping: jest.Mock;
+};
+
+type LocalRedisClientMock = {
+  connect: jest.Mock;
+  del: jest.Mock;
+  get: jest.Mock;
+  multi: jest.Mock;
+  on: jest.Mock;
+  ping: jest.Mock;
+  sAdd: jest.Mock;
+  sMembers: jest.Mock;
+  set: jest.Mock;
+};
+
+const loadRedisModule = async ({
+  localRedisUrl,
+  upstashValue,
+}: {
+  localRedisUrl?: string;
+  upstashValue?: unknown;
+}) => {
+  jest.resetModules();
+  process.env = {
+    ...originalEnv,
+    REDIS_URL: localRedisUrl,
+    UPSTASH_REDIS_REST_URL: localRedisUrl ? undefined : "https://upstash.test",
+    UPSTASH_REDIS_REST_TOKEN: localRedisUrl ? undefined : "token",
+  };
+
+  const upstashClient: UpstashClientMock = {
+    get: jest.fn().mockResolvedValue(upstashValue ?? null),
+    ping: jest.fn().mockResolvedValue("PONG"),
+  };
+  const localClient: LocalRedisClientMock = {
+    connect: jest.fn().mockResolvedValue(undefined),
+    del: jest.fn(),
+    get: jest.fn().mockResolvedValue("local-value"),
+    multi: jest.fn(),
+    on: jest.fn(),
+    ping: jest.fn().mockResolvedValue("PONG"),
+    sAdd: jest.fn(),
+    sMembers: jest.fn(),
+    set: jest.fn(),
+  };
+
+  jest.doMock("@upstash/redis", () => ({
+    Redis: jest.fn().mockImplementation(() => upstashClient),
+  }));
+  jest.doMock("redis", () => ({
+    createClient: jest.fn().mockImplementation(() => localClient),
+  }));
+
+  const redisModule = await import("./index");
+
+  return {
+    localClient,
+    redisModule,
+    upstashClient,
+  };
+};
+
+describe("redis string helpers", () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  it("로컬 Redis 문자열 값을 그대로 반환한다", async () => {
+    const { redisModule } = await loadRedisModule({
+      localRedisUrl: "redis://localhost:6379",
+    });
+
+    await expect(redisModule.getRedisStringValue("capsule:key")).resolves.toBe(
+      "local-value",
+    );
+  });
+
+  it("Upstash가 object를 반환해도 JSON 문자열로 정규화한다", async () => {
+    const payload = {
+      reservationSessionToken: "session-a",
+      reservationToken: "token-a",
+    };
+    const { redisModule } = await loadRedisModule({
+      upstashValue: payload,
+    });
+
+    await expect(redisModule.getRedisStringValue("capsule:key")).resolves.toBe(
+      JSON.stringify(payload),
+    );
+  });
+});

--- a/src/redis/index.ts
+++ b/src/redis/index.ts
@@ -78,17 +78,29 @@ export const requireRedisClient = async () => {
   return client;
 };
 
+const normalizeRedisStringValue = (value: unknown) => {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (value === null || typeof value === "undefined") {
+    return null;
+  }
+
+  return JSON.stringify(value);
+};
+
 export const getRedisStringValue = async (key: string) => {
   const client = await requireRedisClient();
 
   // 로컬 Redis와 Upstash Redis를 같은 인터페이스로 읽기 위해 분기합니다.
   if (isLocalRedisConfigured && "get" in client) {
-    const value = await (client as LocalRedisClient).get(key);
-    return typeof value === "string" ? value : null;
+    return normalizeRedisStringValue(
+      await (client as LocalRedisClient).get(key),
+    );
   }
 
-  const value = await (client as Redis).get<string>(key);
-  return typeof value === "string" ? value : null;
+  return normalizeRedisStringValue(await (client as Redis).get(key));
 };
 
 export const setRedisStringIfAbsent = async (


### PR DESCRIPTION
## 배포 환경에서만 발생하는 Upstash Redis `get()` 타입 호환 문제 수정

### 문제 재현
- Swagger/배포 환경에서 `slug 예약 -> 바로 생성` 시 `409 SLUG_RESERVATION_MISMATCH` 발생
- `slug A 예약 -> slug B 예약 -> slug A 재확인` 흐름에서도 `409` 발생

### 원인
- 배포 환경은 Upstash Redis 경로를 타는데, `get()` 결과가 JSON string이 아니라 object로 반환됨
- 기존 헬퍼가 문자열만 처리해서 예약 레코드를 `null`로 오판하고, 생성 단계에서 예약 불일치로 이어짐

### 수정 요약
- Redis `get()` 응답이 string/object 둘 다 처리되도록 호환성 보강
- 예약 레코드 파싱 로직이 Upstash 반환 형태를 안전하게 처리하도록 정리
- Redis helper 회귀 테스트 추가

### 검증 항목
- `pnpm test -- --runTestsByPath src/redis/index.test.ts`
- `pnpm test -- --runTestsByPath src/modules/capsules/capsules.repository.test.ts`
- `pnpm typecheck`
- `pnpm audit --prod`
- `pnpm lint`
- `pnpm openapi:check`
- `pnpm build`

### 관련 이슈/PR
- Related: #92
- Follow-up: #94
