### PR TITLE
chore: pnpm 9 기준 고정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178C6?style=for-the-badge&logo=typescript&logoColor=white)
 ![Express](https://img.shields.io/badge/Express-5-000000?style=for-the-badge&logo=express&logoColor=white)
 ![PostgreSQL](https://img.shields.io/badge/PostgreSQL-15-4169E1?style=for-the-badge&logo=postgresql&logoColor=white)
-![pnpm](https://img.shields.io/badge/pnpm-8+-F69220?style=for-the-badge&logo=pnpm&logoColor=white)
+![pnpm](https://img.shields.io/badge/pnpm-9.x-F69220?style=for-the-badge&logo=pnpm&logoColor=white)
 ![Docker](https://img.shields.io/badge/Docker-Compose-2496ED?style=for-the-badge&logo=docker&logoColor=white)
 ![OpenAPI](https://img.shields.io/badge/OpenAPI-Swagger_UI-85EA2D?style=for-the-badge&logo=swagger&logoColor=black)
 
@@ -149,14 +149,18 @@ flowchart LR
 ### 1. Prerequisites
 
 - Node.js `20+`
-- pnpm `8+`
+- pnpm `9.x`
 - Docker / Docker Compose
 
 ### 2. Install Dependencies
 
 ```bash
+corepack enable
+corepack use pnpm@9.0.0
 pnpm install
 ```
+
+`package.json`의 `packageManager`와 동일한 pnpm major를 사용해야 lockfile 해석 차이로 인한 의존성 누락을 피할 수 있습니다.
 
 ### 3. Configure Environment Variables
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "sabujak",
   "version": "1.0.0",
+  "packageManager": "pnpm@9.0.0",
   "engines": {
     "node": ">=20.0.0",
-    "pnpm": ">=8.0.0"
+    "pnpm": ">=9.0.0 <10.0.0"
   },
   "scripts": {
     "dev": "tsx watch src/main.ts",


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- 없음

## 📝 작업 내용

- `package.json`에 `packageManager`와 `engines`를 추가해 pnpm 9 기준을 명시
- README에 `corepack` 기반 설치 절차를 추가해 팀원이 동일한 pnpm major를 사용하도록 안내
- lockfile major mismatch로 의존성 설치 상태가 어긋나는 재발 가능성을 낮춤

## ✅ 확인

- `node -e "const p=require('./package.json'); console.log(p.packageManager); console.log(p.engines.pnpm)"`
  - `pnpm@9.0.0`
  - `>=9.0.0 <10.0.0`
