### PR TITLE
feat: capsule soft delete

### DIFF
--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -4,14 +4,16 @@
 
 CREATE TABLE "capsules" (
 	"id" char(26) PRIMARY KEY NOT NULL,
-	"slug" varchar(50) NOT NULL,
+	"slug" varchar(100) NOT NULL,
 	"title" varchar(100) NOT NULL,
 	"open_at" timestamp with time zone NOT NULL,
 	"expires_at" timestamp with time zone NOT NULL,
 	"version" integer DEFAULT 1 NOT NULL,
 	"password_hash" varchar(255) NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
-	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"original_slug" varchar(50) DEFAULT '' NOT NULL,
+	"deleted_at" timestamp with time zone
 );
 
 CREATE TABLE "messages" (

--- a/drizzle/0002_groovy_red_hulk.sql
+++ b/drizzle/0002_groovy_red_hulk.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "capsules" ALTER COLUMN "slug" SET DATA TYPE varchar(100);--> statement-breakpoint
+ALTER TABLE "capsules" ADD COLUMN "original_slug" varchar(50) DEFAULT '' NOT NULL;--> statement-breakpoint
+ALTER TABLE "capsules" ADD COLUMN "deleted_at" timestamp with time zone;

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,241 @@
+{
+  "id": "3db02573-cf69-476f-b3ab-6157ecf49e42",
+  "prevId": "2080af2c-6734-44cd-a515-cd2667d82550",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.capsules": {
+      "name": "capsules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(26)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "open_at": {
+          "name": "open_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "original_slug": {
+          "name": "original_slug",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "capsules_slug_unq": {
+          "name": "capsules_slug_unq",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capsules_expires_at_idx": {
+          "name": "capsules_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "messages_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "capsule_id": {
+          "name": "capsule_id",
+          "type": "char(26)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messages_capsule_id_nickname_unq": {
+          "name": "messages_capsule_id_nickname_unq",
+          "columns": [
+            {
+              "expression": "capsule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nickname",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_capsule_id_id_idx": {
+          "name": "messages_capsule_id_id_idx",
+          "columns": [
+            {
+              "expression": "capsule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_capsule_id_capsules_id_fk": {
+          "name": "messages_capsule_id_capsules_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "capsules",
+          "columnsFrom": ["capsule_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1776054564909,
       "tag": "0001_modern_masked_marvel",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1776174779498,
+      "tag": "0002_groovy_red_hulk",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "db:repair:legacy-drift": "node --import tsx scripts/repair-db-drift.ts",
     "openapi:generate": "node --import tsx scripts/generate-openapi.ts",
     "openapi:check": "node --import tsx scripts/check-openapi.ts",
+    "batch:expire": "node --import tsx scripts/expire-capsules.ts",
     "prepare": "husky",
     "test:rate-limit": "bash scripts/test-rate-limit.sh",
     "pr-review:prepare": "bash scripts/generate-pr-review-input.sh",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "openapi:generate": "node --import tsx scripts/generate-openapi.ts",
     "openapi:check": "node --import tsx scripts/check-openapi.ts",
     "batch:expire": "node --import tsx scripts/expire-capsules.ts",
+    "db:backfill:original-slug": "node --import tsx scripts/backfill-original-slug.ts",
     "prepare": "husky",
     "test:rate-limit": "bash scripts/test-rate-limit.sh",
     "pr-review:prepare": "bash scripts/generate-pr-review-input.sh",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sabujak",
   "version": "1.0.0",
-  "packageManager": "pnpm@9.0.0",
+  "packageManager": "pnpm@9.15.9",
   "engines": {
     "node": ">=20.0.0",
     "pnpm": ">=9.0.0 <10.0.0"

--- a/scripts/backfill-original-slug.ts
+++ b/scripts/backfill-original-slug.ts
@@ -5,7 +5,7 @@
  * 실행: node --import tsx scripts/backfill-original-slug.ts
  */
 
-import { or, isNull, eq, sql } from "drizzle-orm";
+import { or, and, isNull, eq, sql } from "drizzle-orm";
 import { db } from "../src/db";
 import { capsules } from "../src/db/schema";
 import { logger } from "../src/common/utils/logger";
@@ -14,10 +14,9 @@ async function backfillOriginalSlug() {
   logger.info("[backfill-original-slug] Starting original_slug backfill...");
 
   // original_slug가 NULL이거나 빈 문자열('')인 경우를 모두 대상으로 합니다.
-  // 스키마에 notNull().default('') 설정이 있어 기존 레코드가 NULL 대신 ''로 저장된 경우가 있습니다.
-  const needsBackfill = or(
-    isNull(capsules.originalSlug),
-    eq(capsules.originalSlug, ""),
+  // 삭제되지 않은(deleted_at IS NULL) 활성 캡슐만 대상으로 제한합니다.
+  const needsBackfill = and(
+    or(isNull(capsules.originalSlug), eq(capsules.originalSlug, "")),
     isNull(capsules.deletedAt),
   );
 

--- a/scripts/backfill-original-slug.ts
+++ b/scripts/backfill-original-slug.ts
@@ -1,0 +1,71 @@
+/**
+ * 백필 스크립트: original_slug가 null인 기존 캡슐 레코드에
+ * 현재 slug 값을 original_slug로 저장합니다.
+ *
+ * 실행: node --import tsx scripts/backfill-original-slug.ts
+ */
+
+import { or, isNull, eq, sql } from "drizzle-orm";
+import { db } from "../src/db";
+import { capsules } from "../src/db/schema";
+import { logger } from "../src/common/utils/logger";
+
+async function backfillOriginalSlug() {
+  logger.info("[backfill-original-slug] Starting original_slug backfill...");
+
+  // original_slug가 NULL이거나 빈 문자열('')인 경우를 모두 대상으로 합니다.
+  // 스키마에 notNull().default('') 설정이 있어 기존 레코드가 NULL 대신 ''로 저장된 경우가 있습니다.
+  const needsBackfill = or(
+    isNull(capsules.originalSlug),
+    eq(capsules.originalSlug, ""),
+  );
+
+  try {
+    // 대상 레코드 수를 먼저 확인합니다.
+    const [{ count: pendingCount }] = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(capsules)
+      .where(needsBackfill);
+
+    logger.info(
+      `[backfill-original-slug] Found ${pendingCount} capsule(s) with empty/null original_slug.`,
+    );
+
+    if (Number(pendingCount) === 0) {
+      logger.info("[backfill-original-slug] Nothing to update. Exiting.");
+      process.exit(0);
+    }
+
+    // original_slug가 비어 있는 레코드에 대해 original_slug = slug 로 업데이트합니다.
+    const result = await db
+      .update(capsules)
+      .set({ originalSlug: capsules.slug })
+      .where(needsBackfill)
+      .returning({
+        id: capsules.id,
+        slug: capsules.slug,
+        originalSlug: capsules.originalSlug,
+      });
+
+    logger.info(
+      `[backfill-original-slug] Successfully updated ${result.length} capsule(s).`,
+    );
+
+    for (const row of result) {
+      logger.info(
+        { id: row.id, slug: row.slug, originalSlug: row.originalSlug },
+        "[backfill-original-slug] Updated capsule.",
+      );
+    }
+
+    process.exit(0);
+  } catch (error) {
+    logger.error(
+      error,
+      "[backfill-original-slug] Failed to backfill original_slug.",
+    );
+    process.exit(1);
+  }
+}
+
+backfillOriginalSlug();

--- a/scripts/backfill-original-slug.ts
+++ b/scripts/backfill-original-slug.ts
@@ -18,6 +18,7 @@ async function backfillOriginalSlug() {
   const needsBackfill = or(
     isNull(capsules.originalSlug),
     eq(capsules.originalSlug, ""),
+    isNull(capsules.deletedAt),
   );
 
   try {

--- a/scripts/expire-capsules.ts
+++ b/scripts/expire-capsules.ts
@@ -1,0 +1,27 @@
+import { logger } from "../src/common/utils/logger";
+import { capsulesRepository } from "../src/modules/capsules/capsules.repository";
+
+async function expireCapsules() {
+  logger.info("[expire-capsules] Starting capsule expiration batch...");
+
+  try {
+    const processedCount = await capsulesRepository.expireCapsules();
+
+    if (processedCount === 0) {
+      logger.info("[expire-capsules] No expired capsules found to process.");
+    } else {
+      logger.info(
+        `[expire-capsules] Successfully processed ${processedCount} capsules.`,
+      );
+    }
+    process.exit(0);
+  } catch (error) {
+    logger.error(
+      error,
+      "[expire-capsules] Failed to process expiration batch.",
+    );
+    process.exit(1);
+  }
+}
+
+expireCapsules();

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -15,7 +15,7 @@ export const capsules = pgTable(
   "capsules",
   {
     id: char("id", { length: 26 }).primaryKey(),
-    slug: varchar("slug", { length: 50 }).notNull(),
+    slug: varchar("slug", { length: 100 }).notNull(),
     title: varchar("title", { length: 100 }).notNull(),
     openAt: timestamp("open_at", { withTimezone: true }).notNull(),
     expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
@@ -27,6 +27,10 @@ export const capsules = pgTable(
     updatedAt: timestamp("updated_at", { withTimezone: true })
       .defaultNow()
       .notNull(),
+    originalSlug: varchar("original_slug", { length: 50 })
+      .notNull()
+      .default(""),
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
   },
   (table) => ({
     slugUniqueIdx: uniqueIndex("capsules_slug_unq").on(table.slug),

--- a/src/modules/capsules/capsules.repository.test.ts
+++ b/src/modules/capsules/capsules.repository.test.ts
@@ -1482,14 +1482,17 @@ describe("CapsulesRepository", () => {
         passwordHash: buildPasswordHash("1234"),
       });
 
-      const deleteReturningMock = jest.fn().mockResolvedValue([]);
-      const deleteWhereMock = jest.fn().mockReturnValue({
-        returning: deleteReturningMock,
+      const updateReturningMock = jest.fn().mockResolvedValue([]);
+      const updateWhereMock = jest.fn().mockReturnValue({
+        returning: updateReturningMock,
       });
-      const deleteMock = jest.fn().mockReturnValue({ where: deleteWhereMock });
+      const updateSetMock = jest.fn().mockReturnValue({
+        where: updateWhereMock,
+      });
+      const updateMock = jest.fn().mockReturnValue({ set: updateSetMock });
       db.transaction.mockImplementation(async (callback) =>
         callback({
-          delete: deleteMock,
+          update: updateMock,
           select: selectMocks.selectMock,
         }),
       );
@@ -1502,22 +1505,25 @@ describe("CapsulesRepository", () => {
       ).rejects.toBeInstanceOf(CapsuleNotFoundException);
     });
 
-    it("비밀번호가 일치하면 트랜잭션 내부에서 캡슐을 Hard Delete 한다", async () => {
+    it("비밀번호가 일치하면 트랜잭션 내부에서 캡슐을 Soft Delete 한다", async () => {
       const selectMocks = buildLockedCapsuleSelectMocks({
         id: "01TESTCAPSULEID123456789012",
         passwordHash: buildPasswordHash("1234"),
       });
 
-      const deleteReturningMock = jest
+      const updateReturningMock = jest
         .fn()
         .mockResolvedValue([{ id: "01TESTCAPSULEID123456789012" }]);
-      const deleteWhereMock = jest.fn().mockReturnValue({
-        returning: deleteReturningMock,
+      const updateWhereMock = jest.fn().mockReturnValue({
+        returning: updateReturningMock,
       });
-      const deleteMock = jest.fn().mockReturnValue({ where: deleteWhereMock });
+      const updateSetMock = jest.fn().mockReturnValue({
+        where: updateWhereMock,
+      });
+      const updateMock = jest.fn().mockReturnValue({ set: updateSetMock });
       db.transaction.mockImplementation(async (callback) =>
         callback({
-          delete: deleteMock,
+          update: updateMock,
           select: selectMocks.selectMock,
         }),
       );
@@ -1531,8 +1537,9 @@ describe("CapsulesRepository", () => {
 
       expect(db.transaction).toHaveBeenCalledTimes(1);
       expect(db.query.capsules.findFirst).not.toHaveBeenCalled();
-      expect(deleteMock).toHaveBeenCalledTimes(1);
-      expect(deleteWhereMock).toHaveBeenCalledTimes(1);
+      expect(updateMock).toHaveBeenCalledTimes(1);
+      expect(updateSetMock).toHaveBeenCalledTimes(1);
+      expect(updateWhereMock).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/modules/capsules/capsules.repository.test.ts
+++ b/src/modules/capsules/capsules.repository.test.ts
@@ -247,12 +247,22 @@ describe("CapsulesRepository", () => {
 
   describe("getCapsuleStats", () => {
     it("전체 캡슐 수와 전체 메시지 수를 함께 반환한다", async () => {
-      const fromCapsulesMock = jest
+      const whereCapsulesMock = jest
         .fn()
         .mockResolvedValue([{ totalCapsuleCount: 12 }]);
-      const fromMessagesMock = jest
+      const fromCapsulesMock = jest
+        .fn()
+        .mockReturnValue({ where: whereCapsulesMock });
+
+      const whereMessagesMock = jest
         .fn()
         .mockResolvedValue([{ totalMessageCount: 77 }]);
+      const innerJoinMock = jest
+        .fn()
+        .mockReturnValue({ where: whereMessagesMock });
+      const fromMessagesMock = jest
+        .fn()
+        .mockReturnValue({ innerJoin: innerJoinMock });
 
       db.select
         .mockReturnValueOnce({ from: fromCapsulesMock })
@@ -283,8 +293,18 @@ describe("CapsulesRepository", () => {
         },
       );
 
-      const fromCapsulesMock = jest.fn().mockReturnValue(capsulesPromise);
-      const fromMessagesMock = jest.fn().mockReturnValue(messagesPromise);
+      const whereCapsulesMock = jest.fn().mockReturnValue(capsulesPromise);
+      const fromCapsulesMock = jest
+        .fn()
+        .mockReturnValue({ where: whereCapsulesMock });
+
+      const whereMessagesMock = jest.fn().mockReturnValue(messagesPromise);
+      const innerJoinMock = jest
+        .fn()
+        .mockReturnValue({ where: whereMessagesMock });
+      const fromMessagesMock = jest
+        .fn()
+        .mockReturnValue({ innerJoin: innerJoinMock });
 
       db.select
         .mockReturnValueOnce({ from: fromCapsulesMock })

--- a/src/modules/capsules/capsules.repository.ts
+++ b/src/modules/capsules/capsules.repository.ts
@@ -229,8 +229,15 @@ export class CapsulesRepository {
   async getCapsuleStats() {
     const [[{ totalCapsuleCount }], [{ totalMessageCount }]] =
       await Promise.all([
-        db.select({ totalCapsuleCount: count() }).from(capsules),
-        db.select({ totalMessageCount: count() }).from(messages),
+        db
+          .select({ totalCapsuleCount: count() })
+          .from(capsules)
+          .where(isNull(capsules.deletedAt)),
+        db
+          .select({ totalMessageCount: count() })
+          .from(messages)
+          .innerJoin(capsules, eq(messages.capsuleId, capsules.id))
+          .where(isNull(capsules.deletedAt)),
       ]);
 
     return {

--- a/src/modules/capsules/capsules.repository.ts
+++ b/src/modules/capsules/capsules.repository.ts
@@ -670,15 +670,18 @@ export class CapsulesRepository {
       // slug 컬럼의 최대 길이가 100자로 확장되었으므로 기존 slug(최대 50자)와 id(26자)를 온전하게 연결합니다.
       const newSlug = `${capsule.slug}-${capsule.id}`;
 
-      await db
+      const [updatedResult] = await db
         .update(capsules)
         .set({
           slug: newSlug,
           deletedAt: new Date(),
         })
-        .where(and(eq(capsules.id, capsule.id), isNull(capsules.deletedAt)));
+        .where(and(eq(capsules.id, capsule.id), isNull(capsules.deletedAt)))
+        .returning({ id: capsules.id });
 
-      processedCount++;
+      if (updatedResult) {
+        processedCount++;
+      }
     }
 
     return processedCount;

--- a/src/modules/capsules/capsules.repository.ts
+++ b/src/modules/capsules/capsules.repository.ts
@@ -1,4 +1,4 @@
-import { and, asc, count, eq } from "drizzle-orm";
+import { and, asc, count, eq, lte, isNull } from "drizzle-orm";
 import { logger } from "../../common/utils/logger";
 import { randomBytes, randomUUID, scrypt, timingSafeEqual } from "node:crypto";
 import { db } from "../../db";
@@ -370,6 +370,7 @@ export class CapsulesRepository {
         .values({
           id: capsuleId,
           slug: input.slug,
+          originalSlug: input.slug,
           title: input.title,
           openAt,
           expiresAt,
@@ -648,6 +649,41 @@ export class CapsulesRepository {
     });
   }
 
+  async expireCapsules() {
+    const now = new Date();
+
+    const expiredCapsules = await db.query.capsules.findMany({
+      columns: {
+        id: true,
+        slug: true,
+      },
+      where: and(lte(capsules.expiresAt, now), isNull(capsules.deletedAt)),
+    });
+
+    if (expiredCapsules.length === 0) {
+      return 0;
+    }
+
+    let processedCount = 0;
+
+    for (const capsule of expiredCapsules) {
+      // slug 컬럼의 최대 길이가 100자로 확장되었으므로 기존 slug(최대 50자)와 id(26자)를 온전하게 연결합니다.
+      const newSlug = `${capsule.slug}-${capsule.id}`;
+
+      await db
+        .update(capsules)
+        .set({
+          slug: newSlug,
+          deletedAt: new Date(),
+        })
+        .where(and(eq(capsules.id, capsule.id), isNull(capsules.deletedAt)));
+
+      processedCount++;
+    }
+
+    return processedCount;
+  }
+
   async deleteCapsule(input: DeleteCapsuleInputDto) {
     await db.transaction(async (tx) => {
       // 삭제 대상 행을 잠가 수정/삭제 충돌을 직렬화합니다.
@@ -674,9 +710,16 @@ export class CapsulesRepository {
         throw new ForbiddenPasswordException();
       }
 
-      // messages 는 FK ON DELETE CASCADE 로 함께 정리되므로 capsule 만 삭제합니다.
+      // messages는 유지하며, capsule의 slug를 변형하고 deletedAt을 기록하는 soft delete를 수행합니다.
+      // slug 컬럼의 최대 길이가 100자로 확장되었으므로 기존 slug(최대 50자)와 id(26자)를 온전하게 연결합니다.
+      const newSlug = `${input.slug}-${capsule.id}`;
+
       const deletedCapsules = await tx
-        .delete(capsules)
+        .update(capsules)
+        .set({
+          slug: newSlug,
+          deletedAt: new Date(),
+        })
         .where(eq(capsules.slug, input.slug))
         .returning({ id: capsules.id });
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#96 

### 📝 작업 내용

- DB 스키마 변경: `original_slug`, `deleted_at` 컬럼 추가 및 slug 컬럼 `varcher(100)`으로 확장
- Soft Delete 로직 구현: 삭제/만료 시 데이터를 보존하고 슬러그를 `${slug}-${id}`로 변경 로직 추가 
- 만료 처리 배치 추가: 만료된 캡슐을 일괄 Soft Delete 처리하는 스크립트 작성
- 테스트 업데이트: 변경된 로직에 맞춰 레포지토리 유닛 테스트 코드 수정

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

로컬 DB 마이그레이션이 정상적으로 동작하는지 확인 부탁드립니다.
slug 컬럼을 varchar(50) → varchar(100)으로 확장했는데, 적합한 작업이었는지 확인 부탁드립니당!
추가로 로직이 이상한 부분이 있다면 말씀해주세요!

## 📚 참고할만한 자료(선택)
